### PR TITLE
added seed support, rgb_array rendering mode, more convenient video r…

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -6,3 +6,5 @@ dependencies:
   - numpy
   - matplotlib
   - gym
+  - imageio-ffmpeg
+  - imageio

--- a/mapgen/__init__.py
+++ b/mapgen/__init__.py
@@ -1,1 +1,2 @@
 from mapgen.env import Dungeon
+from mapgen.recorder import VideoRecorder

--- a/mapgen/dungeon.py
+++ b/mapgen/dungeon.py
@@ -194,7 +194,7 @@ class DungeonGenerator():
 
 
     def gen_level(self):
-
+        self.level = []
         # build an empty dungeon, blank the room and corridor lists
         for i in range(self.height):
             self.level.append([TileKind.UNKNOWN] * self.width)

--- a/mapgen/env.py
+++ b/mapgen/env.py
@@ -1,7 +1,10 @@
-import math
 import gym
-from gym import spaces
+import math
+import random
 import numpy as np
+from gym import spaces
+
+from PIL import Image
 from mapgen.dungeon import DungeonGenerator
 from mapgen.map import Map, Move
 from mapgen.agent import Agent, Position, Orientation
@@ -41,7 +44,6 @@ class Dungeon(gym.Env):
         self.action_space = spaces.Discrete(3)
 
     def reset(self):
-
         """Resets the environment to an initial state and returns an initial
         observation.
 
@@ -55,7 +57,6 @@ class Dungeon(gym.Env):
             observation (object): the initial observation.
         """
         # generate level
-
         self._gen.gen_level()
         self._map = Map(self._gen.level)
 
@@ -69,7 +70,6 @@ class Dungeon(gym.Env):
         return observation
 
     def step(self, action: int):
-        
         """Run one timestep of the environment's dynamics. When end of
         episode is reached, you are responsible for calling `reset()`
         to reset this environment's state.
@@ -106,10 +106,9 @@ class Dungeon(gym.Env):
         }
         self._step += 1
 
-        return observation, reward , done or self._step == self._max_steps, info
+        return observation, reward, done or self._step == self._max_steps, info
 
-
-    def render(self, mode='human'):
+    def render(self, mode='rgb_array', size=None):
         """Renders the environment.
 
         The set of supported modes varies per environment. (And some
@@ -121,34 +120,26 @@ class Dungeon(gym.Env):
         - rgb_array: Return an numpy.ndarray with shape (x, y, 3),
           representing RGB values for an x-by-y pixel image, suitable
           for turning into a video.
-        - ansi: Return a string (str) or StringIO.StringIO containing a
-          terminal-style text representation. The text can include newlines
-          and ANSI escape sequences (e.g. for colors).
-
-        Note:
-            Make sure that your class's metadata 'render.modes' key includes
-              the list of supported modes. It's recommended to call super()
-              in implementations to use the functionality of this method.
 
         Args:
             mode (str): the mode to render with
 
-        Example:
-
-        class MyEnv(Env):
-            metadata = {'render.modes': ['human', 'rgb_array']}
-
-            def render(self, mode='human'):
-                if mode == 'rgb_array':
-                    return np.array(...) # return RGB frame suitable for video
-                elif mode == 'human':
-                    ... # pop up a window and render
-                else:
-                    super(MyEnv, self).render(mode=mode) # just raise an exception
         """
         if mode == "rgb_array":
-            raise NotImplementedError
+            render_img = Image.fromarray(self._map.render(self._agent))
+
+            if size is not None:
+                render_img = render_img.resize((size, size), Image.NEAREST)
+
+            return np.asarray(render_img)
         elif mode == "human":
             print(f"Step {self._step}")
             print(self._map.show(self._agent))
             print(f"Explored: {self._map._total_explored}/{self._map._visible_cells} cells ({self._map._total_explored / self._map._visible_cells * 100:.2f}%)")
+        else:
+            raise RuntimeError(f"Unknown render mode, expected one of ['human', 'rgb_array']. Got: {mode}")
+
+    def seed(self, seed=None):
+        random.seed(seed)
+        np.random.seed(seed)
+        self.action_space.seed(seed)

--- a/mapgen/env.py
+++ b/mapgen/env.py
@@ -91,7 +91,7 @@ class Dungeon(gym.Env):
               - moved: whether an agent made a move (didn't collide with an obstacle)
         """
         action = Move(action-1)
-        observation, explored, done, moved = self._map.step(self._agent, action, self.observation_size)
+        observation, explored, done, moved, is_new = self._map.step(self._agent, action, self.observation_size)
 
         # set reward as a fraction of new explored cells (so total reward is 1.0)
         reward = explored /  self._map._visible_cells
@@ -102,7 +102,8 @@ class Dungeon(gym.Env):
             "total_explored": self._map._total_explored,
             "new_explored": explored,
             "avg_explored_per_step": self._map._total_explored / self._step,
-            "moved": moved
+            "moved": moved,
+            "is_new": is_new
         }
         self._step += 1
 

--- a/mapgen/map.py
+++ b/mapgen/map.py
@@ -122,10 +122,12 @@ class Map:
             agent.orientation = orientation
             moved = True
 
+        is_new = int(not self._trajectory[agent.position.y, agent.position.x])
+
         explored = self.update_explored_area(agent, align_with_map=True)
         success = self._total_explored == self._visible_cells
         obs = self.get_observation(agent, observation_size)
-        return obs, explored, success, moved
+        return obs, explored, success, moved, is_new
 
 
     def get_random_free_position(self) -> Tuple[int, int]:

--- a/mapgen/recorder.py
+++ b/mapgen/recorder.py
@@ -1,0 +1,34 @@
+import os
+import gym
+import uuid
+import imageio
+
+
+class VideoRecorder(gym.Wrapper):
+    def __init__(self, env, video_path, size=512, fps=60, extension="mp4"):
+        super().__init__(env)
+        assert extension in {"mp4", "gif"}, "wrong video extension, supported only mp4 or gif"
+        self.fps = fps
+        self.size = size
+        self.extension = extension
+
+        os.makedirs(video_path, exist_ok=True)
+        self.video_path = video_path
+        self._frames = None
+
+    def _save(self):
+        assert self._frames is not None
+        filename = os.path.join(self.video_path, str(uuid.uuid4()) + f".{self.extension}")
+        imageio.mimsave(filename, self._frames, fps=self.fps)
+
+    def reset(self):
+        state = self.env.reset()
+        self._frames = [self.env.render(mode="rgb_array", size=self.size)]
+        return state
+
+    def step(self, action):
+        state, reward, done, info = self.env.step(action)
+        self._frames.append(self.env.render(mode="rgb_array", size=self.size))
+        if done:
+            self._save()
+        return state, reward, done, info

--- a/run.py
+++ b/run.py
@@ -1,28 +1,11 @@
-import numpy as np
-from mapgen import Dungeon
+from mapgen import Dungeon, VideoRecorder
 
 
 if __name__ == "__main__":
-    import matplotlib.pyplot as plt
+    env = VideoRecorder(Dungeon(30, 30, min_room_xy=7, max_room_xy=14, max_steps=200), video_path="videos", size=512, fps=60, extension="gif")    
+    env.seed(10)
 
-    env = Dungeon(30, 30, min_room_xy=7, max_room_xy=14)
-    obs = env.reset()
-    env.render("human")
-    from PIL import Image
-    Image.fromarray(env._map.render(env._agent)).convert('RGB').resize((500, 500), Image.NEAREST).save('tmp.png')
-
-    frames = []
-
-    for _ in range(200):
-        action = np.random.choice(3)
-
-        frame = Image.fromarray(env._map.render(env._agent)).convert('RGB').resize((500, 500), Image.NEAREST).quantize()
-        frames.append(frame)
-
-        #frame.save('tmp1.png')
-        obs, reward, done, info = env.step(action)
-        env.render("human")
-        if done:
-            break
-
-    frames[0].save("out.gif", save_all=True, append_images=frames[1:], loop=0, duration=1000/60)
+    state, done = env.reset(), False
+    while not done:
+        action = env.action_space.sample()
+        state, reward, done, info = env.step(action)


### PR DESCRIPTION
Сделал немного более gym-like. 

- Добавил env.seed(), т.к. по опыту с рл пытаться делать что-то со средой без сида сложно
- Чуть чуть поправил рендеринг в rgb_array моде, чтобы было удобнее рендерить
- Дописал враппер для записи видео/гифок траекторий, пример в run.py

Думаю, так или иначе примерно эти же изменения написал бы каждый во время выполнения домашки, так что лучше если это будет здесь